### PR TITLE
Detection of TheWall.ahk on Julti startup

### DIFF
--- a/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
@@ -1,5 +1,6 @@
 package xyz.duncanruns.julti.gui;
 
+import org.apache.logging.log4j.Level;
 import xyz.duncanruns.julti.Julti;
 import xyz.duncanruns.julti.JultiOptions;
 import xyz.duncanruns.julti.affinity.AffinityManager;
@@ -22,6 +23,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static xyz.duncanruns.julti.Julti.log;
 
 public class OptionsGUI extends JFrame {
     private boolean closed = false;
@@ -663,5 +666,10 @@ public class OptionsGUI extends JFrame {
             SleepBGUtil.disableLock();
             DoAllFastUtil.doAllFast(minecraftInstance -> minecraftInstance.ensureResettingWindowState(false));
         });
+        try {
+            Julti.isWallAHKOpen();
+        } catch (Exception e) {
+            Julti.log(Level.ERROR, "Failed to detect Wall Macro.");
+        }
     }
 }


### PR DESCRIPTION
Added detection of Specnr's TheWall.ahk script on startup of Julti.
REALLY MESSY, probably a more efficient way of doing this but in my tests it has worked.
also im too dumb to figure out how to make it so julti detects if the macro is opened while julti is opened, as opposed to only being able to detect it if the macro was opened before julti. someone smart can do it or teach me.