### PR TITLE
a few more things

### DIFF
--- a/src/main/java/xyz/duncanruns/julti/Julti.java
+++ b/src/main/java/xyz/duncanruns/julti/Julti.java
@@ -318,7 +318,13 @@ public final class Julti {
     }
 
     public void focusWall() {
-        SleepBGUtil.disableLock();
+        this.focusWall(true);
+    }
+
+    public void focusWall(boolean disableLock) {
+        if (disableLock) {
+            SleepBGUtil.disableLock();
+        }
         AtomicReference<HWND> wallHwnd = new AtomicReference<>(ActiveWindowManager.getLastWallHwnd());
         if (wallHwnd.get() == null) {
             User32.INSTANCE.EnumWindows((hwnd, data) -> {

--- a/src/main/java/xyz/duncanruns/julti/JultiOptions.java
+++ b/src/main/java/xyz/duncanruns/julti/JultiOptions.java
@@ -141,6 +141,7 @@ public final class JultiOptions {
     public boolean preventWindowNaming = false;
     public boolean alwaysOnTopProjector = false;
     public boolean minimizeProjectorWhenPlaying = false;
+    public boolean activateProjectorOnReset = false;
     public boolean useAltSwitching = false;
     public boolean allowResetDuringGenerating = false;
     // public boolean forceActivate = false;

--- a/src/main/java/xyz/duncanruns/julti/gui/ControlPanel.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/ControlPanel.java
@@ -87,7 +87,8 @@ public class ControlPanel extends JPanel {
                 public void actionPerformed(ActionEvent e) {
                     Thread.currentThread().setName("julti-gui");
                     SleepBGUtil.disableLock();
-                    Julti.doLater(() -> DoAllFastUtil.doAllFast(minecraftInstance -> minecraftInstance.ensureResettingWindowState(false)));
+                    // ensure instance is unfullscreened and unminimized
+                    Julti.doLater(() -> DoAllFastUtil.doAllFast(minecraftInstance -> minecraftInstance.ensureInitialWindowState()));
                 }
             });
 

--- a/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
@@ -111,6 +111,8 @@ public class OptionsGUI extends JFrame {
 
         panel.add(GUIUtil.createSpacer());
         panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Use Alt Switching", "useAltSwitching")));
+        panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Activate Projector On Reset", "Recommended for use with Bypass Wall in conjunction with thin BT", "activateProjectorOnReset")));
+
 
         panel.add(GUIUtil.createSpacer());
         panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Allow Reset During Generating", "allowResetDuringGenerating")));

--- a/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
@@ -86,10 +86,13 @@ public class OptionsGUI extends JFrame {
 
         if (options.autoFullscreen) {
             panel.add(GUIUtil.createSpacer());
-            panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Fullscreen Before Unpause (Could fix mouse issues)", "fullscreenBeforeUnpause")));
+            panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Fullscreen Before Unpause", "May reduce cursor issues, especially for thin BT users.", "fullscreenBeforeUnpause")));
 
             panel.add(GUIUtil.createSpacer());
-            panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Use Playing Size w/ Fullscreen", "usePlayingSizeWithFullscreen", b -> this.reload())));
+            panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Use Playing Size w/ Fullscreen", "If unchecked, ignores using the Playing Window Size set in Window settings.", "usePlayingSizeWithFullscreen", b -> this.reload())));
+            
+            panel.add(GUIUtil.createSpacer());
+            panel.add(GUIUtil.leftJustify(GUIUtil.createValueChangerButton("fullscreenDelay", "Added Fullscreen Delay", this, "ms")));
         }
         panel.add(GUIUtil.createSpacer());
         panel.add(GUIUtil.createSeparator());
@@ -110,9 +113,10 @@ public class OptionsGUI extends JFrame {
         panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Minimize Projector When Playing", "minimizeProjectorWhenPlaying")));
 
         panel.add(GUIUtil.createSpacer());
-        panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Use Alt Switching", "useAltSwitching")));
         panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Activate Projector On Reset", "Recommended for use with Bypass Wall in conjunction with thin BT", "activateProjectorOnReset")));
 
+        panel.add(GUIUtil.createSpacer());
+        panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Use Alt Switching", "Presses LAlt when switching windows - recommended for those with LAlt unbound", "useAltSwitching")));
 
         panel.add(GUIUtil.createSpacer());
         panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Allow Reset During Generating", "allowResetDuringGenerating")));
@@ -270,6 +274,7 @@ public class OptionsGUI extends JFrame {
                     options.preventWindowNaming = false;
                     options.alwaysOnTopProjector = false;
                     options.minimizeProjectorWhenPlaying = false;
+                    options.activateProjectorOnReset = false;
                     options.useAltSwitching = false;
                     options.allowResetDuringGenerating = false;
                 });

--- a/src/main/java/xyz/duncanruns/julti/instance/MinecraftInstance.java
+++ b/src/main/java/xyz/duncanruns/julti/instance/MinecraftInstance.java
@@ -142,6 +142,13 @@ public class MinecraftInstance {
         this.checkFabricMods();
 
         this.discoverName();
+
+        // check if fullscreen is true in standardoptions (bad)
+        if (GameOptionsUtil.tryGetStandardOption(this.getPath(), "fullscreen") == "true")
+        {
+            Julti.log(Level.WARN, this.getName() + " has fullscreen set to true in standardsettings!\r\n" +
+            "To prevent any issues, please press Plugins > Open > Yes.");
+        }
     }
 
     private void checkFabricMods() {

--- a/src/main/java/xyz/duncanruns/julti/instance/MinecraftInstance.java
+++ b/src/main/java/xyz/duncanruns/julti/instance/MinecraftInstance.java
@@ -147,7 +147,7 @@ public class MinecraftInstance {
         if (GameOptionsUtil.tryGetStandardOption(this.getPath(), "fullscreen") == "true")
         {
             Julti.log(Level.WARN, this.getName() + " has fullscreen set to true in standardsettings!\r\n" +
-            "To prevent any issues, please press Plugins > Open > Yes.");
+            "To prevent any issues, please press Plugins > Open Standard Manager > Yes, to optimize your standardoptions.");
         }
     }
 

--- a/src/main/java/xyz/duncanruns/julti/instance/MinecraftInstance.java
+++ b/src/main/java/xyz/duncanruns/julti/instance/MinecraftInstance.java
@@ -315,7 +315,7 @@ public class MinecraftInstance {
             }
         }
         if (doingSetup) {
-            Julti.doLater(() -> this.ensureResettingWindowState(false));
+            this.ensureInitialWindowState();
         } else {
             PluginEvents.InstanceEventType.ACTIVATE.runAll(this);
         }
@@ -613,6 +613,13 @@ public class MinecraftInstance {
                 (options.maximizeWhenResetting && !options.useBorderless),
                 options.windowPosIsCenter ? WindowStateUtil.withTopLeftToCenter(bounds) : bounds,
                 offload);
+    }
+
+    public void ensureInitialWindowState() {
+        // ensure instance is unfullscreened and unminimized
+        this.ensureNotFullscreen();
+        User32.INSTANCE.ShowWindow(this.hwnd, User32.SW_NORMAL);
+        Julti.doLater(() -> this.ensureResettingWindowState(false));
     }
 
     public void ensurePlayingWindowState(boolean offload) {

--- a/src/main/java/xyz/duncanruns/julti/resetting/WallResetManager.java
+++ b/src/main/java/xyz/duncanruns/julti/resetting/WallResetManager.java
@@ -382,6 +382,10 @@ public class WallResetManager extends ResetManager {
             return false;
         } else {
             this.unlockInstance(nextInstance);
+            // activate projector - avoid previous instances behind selected instance when using thin BT, etc.
+            if (options.activateProjectorOnReset) {
+                Julti.getJulti().focusWall(false);
+            }
             Julti.getJulti().activateInstance(nextInstance);
             return true;
         }

--- a/src/main/java/xyz/duncanruns/julti/util/GameOptionsUtil.java
+++ b/src/main/java/xyz/duncanruns/julti/util/GameOptionsUtil.java
@@ -124,7 +124,7 @@ public final class GameOptionsUtil {
                 return null;
             }
         } catch (StackOverflowError e) {
-            Julti.log(Level.ERROR, "Error reading standardoptions.txt! Press Plugins > Open > Yes to try and fix.");
+            Julti.log(Level.ERROR, "Error reading standardoptions.txt! Press Plugins > Open Standard Manager > Yes to try and fix your standardoptions.txt.");
             return null;
         }
 
@@ -144,7 +144,7 @@ public final class GameOptionsUtil {
                             "- Press Instance Utilities > Close All Instances\r\n" +
                             "- Delete standardoptions.txt on your desktop AND in instance 1's .minecraft/config folder\r\n" +
                             "- Launch and close instance 1\r\n" +
-                            "- In Julti, press Plugins > Open > Yes > OK > Yes > Apply to All Instances"
+                            "- In Julti, press Plugins > Open Standard Manager > Yes > OK > Yes > Apply to All Instances, to fix your standardoptions.txt"
                     );
                     return null;
                 }


### PR DESCRIPTION
activate projector on reset fixes this issue with bypass wall & thin bt:
![image](https://github.com/DuncanRuns/Julti/assets/30545768/384d2d11-9113-43ee-883f-f3a8d02abd0e)

more aggressively checking for fullscreened/minimized background instances seems good