### PR TITLE
Added LAUNCH plugin event

### DIFF
--- a/src/main/java/xyz/duncanruns/julti/Julti.java
+++ b/src/main/java/xyz/duncanruns/julti/Julti.java
@@ -172,6 +172,7 @@ public final class Julti {
         ResourceUtil.makeResources();
         OBSStateManager.getOBSStateManager().tryOutputLSInfo();
         checkDeleteOldJar();
+        PluginEvents.RunnableEventType.LAUNCH.runAll();
 
         this.reload();
         long cycles = 0;

--- a/src/main/java/xyz/duncanruns/julti/plugin/PluginEvents.java
+++ b/src/main/java/xyz/duncanruns/julti/plugin/PluginEvents.java
@@ -15,6 +15,8 @@ public final class PluginEvents {
         END_TICK,
         // Runs every reload, which is every profile change including the first load
         RELOAD,
+        // Runs when Julti is launched
+        LAUNCH,
         // Runs when Julti is shutting down
         STOP,
         // Runs every time the wall is activated


### PR DESCRIPTION
Super small pr, but found myself needing this while writing a plugin and saw discussion about it in the disc. Not too sure where in the run function launch events should be ran, but figured it should be before reload events