### PR TITLE
Program launcher tweaks

### DIFF
--- a/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
@@ -12,11 +12,14 @@ import xyz.duncanruns.julti.util.*;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
+import javax.swing.filechooser.FileView;
 import java.awt.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttributeView;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -265,14 +268,16 @@ public class OptionsGUI extends JFrame {
     }
 
     private void browseForLauncherProgram() {
-        JFileChooser jfc = new JFileChooser();
-        jfc.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        jfc.setDialogTitle("Julti: Choose Program");
-
-        int val = jfc.showOpenDialog(this);
-        if (val == JFileChooser.APPROVE_OPTION) {
-            JultiOptions.getJultiOptions().launchingProgramPaths.add(jfc.getSelectedFile().toPath().toString());
+        FileDialog dialog = new FileDialog((Frame)null, "Julti: Choose Program");
+        dialog.setMode(FileDialog.LOAD);
+        dialog.setMultipleMode(true);
+        dialog.setVisible(true);
+        if (dialog.getFiles() != null) {
+            for (File file : dialog.getFiles()) {
+                JultiOptions.getJultiOptions().launchingProgramPaths.add(file.getAbsolutePath());
+            }
         }
+        dialog.dispose();
     }
 
     private void addComponentsOther() {

--- a/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
@@ -353,7 +353,9 @@ public class OptionsGUI extends JFrame {
         possibleLocations.add(userHome.resolve("AppData").resolve("Roaming"));
         possibleLocations.add(userHome.resolve("AppData").resolve("Local").resolve("Programs"));
         possibleLocations.add(userHome.resolve("Downloads"));
-        possibleLocations.add(Paths.get("C:\\"));
+        for (File drive : File.listRoots()) {
+            possibleLocations.add(Paths.get(drive.toString()));
+        }
 
         List<Path> candidates = new ArrayList<>();
         for (Path possibleLocation : possibleLocations) {


### PR DESCRIPTION
Helloooo I added some changes to program launcher

**Migrate from file chooser to file dialog**
The built in java file chooser was unusable on my machine, and surely someone else will have that issue, so I migrated the file chooser to awt file dialog. It's way quicker and has better multiple selection support. It doesn't have the same theme as everything else so if that's important then that's a downside. I could also migrate the multimc chooser to use it too.

**Check all drives roots for multimc**
Scans drives other than "C:\" for multimc. I don't _think_ this will create any jank, but I could be wrong.

**Add right click popup to program launching**
Completely removes the little buttons for remove and add and changes it to a right click popup menu. I think it improves user experience

lmk if any changes are needed. thanks for your time!