### PR TITLE
fix hanging w/ fullscreen check in 1.19+

### DIFF
--- a/src/main/java/xyz/duncanruns/julti/instance/MinecraftInstance.java
+++ b/src/main/java/xyz/duncanruns/julti/instance/MinecraftInstance.java
@@ -496,7 +496,7 @@ public class MinecraftInstance {
 
 
     public boolean isFullscreen() {
-        if (MCVersionUtil.isOlderThan(this.versionString, "1.16")) {
+        if (MCVersionUtil.isOlderThan(this.versionString, "1.16") || MCVersionUtil.isNewerThan(this.versionString, "1.18.2")) {
             return this.activeSinceReset && JultiOptions.getJultiOptions().autoFullscreen && WindowStateUtil.isHwndBorderless(this.hwnd);
         } else {
             return GameOptionsUtil.tryGetBoolOption(this.getPath(), "fullscreen", false);


### PR DESCRIPTION
1.16-1.18.2 all update options.txt accordingly when fullscreen is toggled

mojabg broke it aaigain in 1.19 ,. Yes