### PR TITLE
Improve logging system

### DIFF
--- a/src/main/java/xyz/duncanruns/julti/Julti.java
+++ b/src/main/java/xyz/duncanruns/julti/Julti.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import xyz.duncanruns.julti.affinity.AffinityManager;
 import xyz.duncanruns.julti.gui.JultiGUI;
 import xyz.duncanruns.julti.hotkey.HotkeyManager;
@@ -77,6 +78,7 @@ public final class Julti {
     }
 
     public static void log(Level level, String message) {
+        Configurator.setRootLevel(JultiOptions.getJultiOptions().showDebug ? Level.DEBUG : Level.INFO); // whether to write debug logs to latest.log (info is default)
         LOGGER.log(level, message);
         LogReceiver.receive(level, message);
     }

--- a/src/main/java/xyz/duncanruns/julti/gui/ControlPanel.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/ControlPanel.java
@@ -143,6 +143,17 @@ public class ControlPanel extends JPanel {
                 }
             });
 
+            GUIUtil.addMenuItem(menu, "Open .Julti", new AbstractAction() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    try {
+                        Desktop.getDesktop().browse(JultiOptions.getJultiDir().toAbsolutePath().toUri());
+                    } catch (IOException ex) {
+                        Julti.log(Level.ERROR, "Failed to open .Julti folder:\n" + ExceptionUtil.toDetailedString(ex));
+                    }
+                }
+            });
+
             Point mousePos = this.getMousePosition();
             if (mousePos == null) {
                 mousePos = new Point(0, 0);

--- a/src/main/java/xyz/duncanruns/julti/gui/LogPanel.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/LogPanel.java
@@ -2,6 +2,7 @@ package xyz.duncanruns.julti.gui;
 
 import com.formdev.flatlaf.ui.FlatBorder;
 import com.formdev.flatlaf.ui.FlatMarginBorder;
+import com.google.common.collect.EvictingQueue;
 import xyz.duncanruns.julti.command.CommandManager;
 import xyz.duncanruns.julti.management.LogReceiver;
 
@@ -12,6 +13,9 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 
 public class LogPanel extends JPanel {
+
+    private final static int MAX_LOG_ENTRIES = 2000; // arbitrary number, can be changed
+    private final EvictingQueue<String> logs = EvictingQueue.create(MAX_LOG_ENTRIES);
 
     public LogPanel() {
         this.setupWindow();
@@ -27,10 +31,13 @@ public class LogPanel extends JPanel {
     private void createTextArea() {
         JTextArea textArea = new JTextArea();
         LogReceiver.setLogConsumer(s -> {
-            if (!textArea.getText().isEmpty()) {
-                textArea.append("\n");
+            logs.add(s);
+
+            textArea.setText(null);
+            if (logs.size() >= MAX_LOG_ENTRIES) {
+                textArea.setText("Logs have been truncated. To view the full logs, go to Options > Other > View Julti Logs.\n\n");
             }
-            textArea.append(s);
+            textArea.append(String.join("\n", logs));
         });
         textArea.setEditable(false);
         textArea.setBorder(new FlatBorder());

--- a/src/main/java/xyz/duncanruns/julti/gui/LogPanel.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/LogPanel.java
@@ -2,20 +2,19 @@ package xyz.duncanruns.julti.gui;
 
 import com.formdev.flatlaf.ui.FlatBorder;
 import com.formdev.flatlaf.ui.FlatMarginBorder;
-import com.google.common.collect.EvictingQueue;
 import xyz.duncanruns.julti.command.CommandManager;
 import xyz.duncanruns.julti.management.LogReceiver;
 
 import javax.swing.*;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultCaret;
 import java.awt.*;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class LogPanel extends JPanel {
-
-    private final static int MAX_LOG_ENTRIES = 2000; // arbitrary number, can be changed
-    private final EvictingQueue<String> logs = EvictingQueue.create(MAX_LOG_ENTRIES);
+    private final static int MAX_LOG_CHARS = 3000; // arbitrary number, can be changed
 
     public LogPanel() {
         this.setupWindow();
@@ -30,14 +29,29 @@ public class LogPanel extends JPanel {
 
     private void createTextArea() {
         JTextArea textArea = new JTextArea();
+        AtomicInteger totalChars = new AtomicInteger();
         LogReceiver.setLogConsumer(s -> {
-            logs.add(s);
-
-            textArea.setText(null);
-            if (logs.size() >= MAX_LOG_ENTRIES) {
-                textArea.setText("Logs have been truncated. To view the full logs, go to Options > Other > View Julti Logs.\n\n");
+            if (totalChars.get() > 0) {
+                s = "\n" + s;
             }
-            textArea.append(String.join("\n", logs));
+            textArea.append(s);
+            totalChars.addAndGet(s.length());
+            if (totalChars.get() > MAX_LOG_CHARS) {
+                // We could just remove totalChars.get() - MAX_LOG_CHARS, but that could cut off some lines, so lets cut it off near at a nearby newline
+                // This means once MAX_LOG_CHARS is reached, we actually stay a tiny bit over it
+                int toRemove;
+                try {
+                    toRemove = textArea.getText(0, totalChars.get() - MAX_LOG_CHARS).lastIndexOf("\n");
+                } catch (BadLocationException e) {
+                    throw new RuntimeException(e);
+                }
+                if (toRemove == -1) {
+                    return;
+                }
+                toRemove++; // Include the newline itself for removal, as replaceRange's end is exclusive
+                textArea.replaceRange(null, 0, toRemove);
+                totalChars.addAndGet(-toRemove);
+            }
         });
         textArea.setEditable(false);
         textArea.setBorder(new FlatBorder());

--- a/src/main/java/xyz/duncanruns/julti/gui/LogPanel.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/LogPanel.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class LogPanel extends JPanel {
     private final static int MAX_LOG_CHARS = 3000; // arbitrary number, can be changed
-    private final static String TRUNCATE_MESSAGE = "Logs have been truncated. To view the full logs, go to Options > Other > View Julti Logs.\n\n";
+    private final static String TRUNCATE_MESSAGE = "Logs have been truncated. To view the full logs, go to File Utilities... -> Open .Julti -> logs.\n\n";
     private final static int TRUNCATE_MESSAGE_LEN = TRUNCATE_MESSAGE.length();
 
     public LogPanel() {

--- a/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
@@ -380,21 +380,6 @@ public class OptionsGUI extends JFrame {
         panel.add(GUIUtil.createSeparator());
         panel.add(GUIUtil.createSpacer());
 
-        panel.add(GUIUtil.leftJustify(new JLabel("Julti logs:")));
-        panel.add(GUIUtil.createSpacer());
-
-        panel.add(GUIUtil.leftJustify(GUIUtil.getButtonWithMethod(new JButton("View Julti Logs"), actionEvent -> {
-            try {
-                Desktop.getDesktop().browse(JultiOptions.getJultiDir().resolve("logs").toAbsolutePath().toUri());
-            } catch (IOException e) {
-                Julti.log(Level.ERROR, "Failed to open logs folder:\n" + ExceptionUtil.toDetailedString(e));
-            }
-        })));
-        panel.add(GUIUtil.createSpacer());
-
-        panel.add(GUIUtil.createSeparator());
-        panel.add(GUIUtil.createSpacer());
-
         panel.add(GUIUtil.leftJustify(GUIUtil.createCheckBoxFromOption("Minimize Julti To System Tray", "Minimizing Julti will move it to an icon in the system tray (bottom right).", "minimizeToTray", JultiGUI.getJultiGUI().getJultiIcon()::setTrayIconListener)));
         panel.add(GUIUtil.createSpacer());
 

--- a/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
+++ b/src/main/java/xyz/duncanruns/julti/gui/OptionsGUI.java
@@ -1,5 +1,6 @@
 package xyz.duncanruns.julti.gui;
 
+import org.apache.logging.log4j.Level;
 import xyz.duncanruns.julti.Julti;
 import xyz.duncanruns.julti.JultiOptions;
 import xyz.duncanruns.julti.affinity.AffinityManager;
@@ -18,6 +19,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -373,6 +375,21 @@ public class OptionsGUI extends JFrame {
         }
 
         panel.add(GUIUtil.leftJustify(GUIUtil.createValueChangerButton("launchDelay", "Delay Between Instance Launches", this, "ms")));
+        panel.add(GUIUtil.createSpacer());
+
+        panel.add(GUIUtil.createSeparator());
+        panel.add(GUIUtil.createSpacer());
+
+        panel.add(GUIUtil.leftJustify(new JLabel("Julti logs:")));
+        panel.add(GUIUtil.createSpacer());
+
+        panel.add(GUIUtil.leftJustify(GUIUtil.getButtonWithMethod(new JButton("View Julti Logs"), actionEvent -> {
+            try {
+                Desktop.getDesktop().browse(JultiOptions.getJultiDir().resolve("logs").toAbsolutePath().toUri());
+            } catch (IOException e) {
+                Julti.log(Level.ERROR, "Failed to open logs folder:\n" + ExceptionUtil.toDetailedString(e));
+            }
+        })));
         panel.add(GUIUtil.createSpacer());
 
         panel.add(GUIUtil.createSeparator());

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -10,6 +10,7 @@
                 <TimeBasedTriggeringPolicy/>
                 <OnStartupTriggeringPolicy/>
             </Policies>
+            <ImmediateFlush>true</ImmediateFlush>
         </RollingRandomAccessFile>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
I noticed that when logs get very large (50k+ lines with debug mode), resizing the main Julti GUI would take almost a full second.

- Logs in the main GUI now have a "rolling window" of 2000 lines, which reduces the rendering overhead.
![aKga3xZ7VR](https://github.com/user-attachments/assets/cc0d545e-116a-4699-b6f5-436f127ff83e)
- All logs are immediately flushed to latest.log (the `Configurator.setRootLevel` method was used to disable/enable logging debug messages).
- I also added a "View Julti Logs" button to "Other" options tab.
![DsgDIZZ5Fi](https://github.com/user-attachments/assets/4fef2301-a6d5-4d71-aee7-885077895ea4)
